### PR TITLE
[Fix] use function name inference and computed properties to distinguish `Symbol()` from `Symbol(‘’)`, when available

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
 		"dot-notation": [2, { "allowKeywords": true }],
 		"id-length": [2, { "max": 22, "min": 1, "properties": "never" }],
 		"max-statements-per-line": [2, { "max": 2 }],
+		"no-magic-numbers": 0,
 		"symbol-description": 0
 	}
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
 		"dot-notation": [2, { "allowKeywords": true }],
 		"id-length": [2, { "max": 22, "min": 1, "properties": "never" }],
 		"max-statements-per-line": [2, { "max": 2 }],
+		"max-statements": [2, 11],
 		"no-magic-numbers": 0,
 		"symbol-description": 0
 	}

--- a/helpers/getInferredName.js
+++ b/helpers/getInferredName.js
@@ -6,5 +6,6 @@ try {
 	getInferredName = Function('s', 'return { [s]() {} }[s].name;');
 } catch (e) {}
 
-module.exports = getInferredName && getInferredName.name === 'getInferredName' ? getInferredName : null;
+var inferred = function () {};
+module.exports = getInferredName && inferred.name === 'inferred' ? getInferredName : null;
 

--- a/helpers/getInferredName.js
+++ b/helpers/getInferredName.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var getInferredName;
+try {
+	// eslint-disable-next-line no-new-func
+	getInferredName = Function('s', 'return { [s]() {} }[s].name;');
+} catch (e) {}
+
+module.exports = getInferredName && getInferredName.name === 'getInferredName' ? getInferredName : null;
+

--- a/implementation.js
+++ b/implementation.js
@@ -2,9 +2,17 @@
 
 var hasSymbols = require('has-symbols')();
 var symToStr = hasSymbols ? Function.call.bind(Symbol.prototype.toString) : null;
+var getInferredName = require('./helpers/getInferredName');
 
 module.exports = function description() {
 	var str = symToStr(this); // will throw if not a Symbol
+
+	if (getInferredName) {
+		var name = getInferredName(this);
+		if (name === '') { return; }
+		return name.slice(1, -1); // name.slice('['.length, -']'.length);
+	}
+
 	var desc = str.slice(7, -1); // str.slice('Symbol('.length, -')'.length);
 	if (desc) {
 		return desc;

--- a/shim.js
+++ b/shim.js
@@ -2,6 +2,7 @@
 
 var hasSymbols = require('has-symbols')();
 var polyfill = require('./polyfill');
+var getInferredName = require('./helpers/getInferredName');
 
 var gOPD = Object.getOwnPropertyDescriptor;
 var dP = Object.defineProperty;
@@ -28,6 +29,7 @@ var shimGlobal = function shimGlobalSymbol(getter) {
 	SymNew.prototype = Symbol.prototype;
 	setProto(SymNew, Symbol);
 	Symbol = SymNew; // eslint-disable-line no-native-reassign, no-global-assign
+
 	var boundGetter = Function.call.bind(getter);
 	var wrappedGetter = function description() {
 		/* eslint no-invalid-this: 0 */
@@ -50,7 +52,10 @@ module.exports = function shimSymbolDescription() {
 	var isMissing = !desc || typeof desc.get !== 'function';
 	var isBroken = !isMissing && (typeof Symbol().description !== 'undefined' || Symbol('').description !== '');
 	if (isMissing || isBroken) {
-		return shimGlobal(getter);
+		if (!getInferredName) {
+			return shimGlobal(getter);
+		}
+		define(getter);
 	}
 	return getter;
 };

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"no-invalid-this": 0,
-		"max-nested-callbacks": 0
+		"max-nested-callbacks": 0,
+		"max-statements": 0,
 	}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,17 @@
 'use strict';
 
-var description = require('../');
+var hasSymbols = require('has-symbols')();
 var test = require('tape');
+
+var description = require('../');
 var runTests = require('./tests');
 
 test('as a function', function (t) {
+	if (!hasSymbols) {
+		t.fail('Symbols not supported in this environment');
+		return t.end();
+	}
+
 	t.test('bad array/this value', function (st) {
 		st.throws(function () { description(undefined); }, TypeError, 'undefined is not an object');
 		st.throws(function () { description(null); }, TypeError, 'null is not an object');

--- a/test/shimmed.js
+++ b/test/shimmed.js
@@ -38,7 +38,7 @@ test('shimmed', function (t) {
 		st.end();
 	});
 
-	t.test('only possible when shimmed', function (st) {
+	t.test('only possible when shimmed (or inference is supported)', function (st) {
 		st.equal(Symbol('').description, '', 'Symbol("") description is empty string');
 		st.end();
 	});

--- a/test/shimmed.js
+++ b/test/shimmed.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var shimDescription = require('../shim');
+var originalSymbol = typeof Symbol === 'function' ? Symbol : null;
 shimDescription();
 
 var hasSymbols = require('has-symbols')();
@@ -8,6 +9,7 @@ var test = require('tape');
 var isEnumerable = Object.prototype.propertyIsEnumerable;
 
 var runTests = require('./tests');
+var getInferredName = require('../helpers/getInferredName');
 
 test('shimmed', function (t) {
 	if (!hasSymbols) {
@@ -40,6 +42,11 @@ test('shimmed', function (t) {
 
 	t.test('only possible when shimmed (or inference is supported)', function (st) {
 		st.equal(Symbol('').description, '', 'Symbol("") description is empty string');
+		st.end();
+	});
+
+	t.test('ensure global Symbol is NOT shimmed', { skip: !getInferredName }, function (st) {
+		st.equal(Symbol, originalSymbol, 'global Symbol is not overridden');
 		st.end();
 	});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var hasSymbols = require('has-symbols')();
+var getInferredName = require('../helpers/getInferredName');
 
 module.exports = function (description, t) {
 	t.test('Symbol description', { skip: !hasSymbols }, function (st) {
@@ -13,4 +14,10 @@ module.exports = function (description, t) {
 
 		st.end();
 	});
+
+	t.test('only possible when inference is supported', { skip: !getInferredName }, function (st) {
+		st.equal(description(Symbol('')), '', 'Symbol("") description is empty string');
+		st.end();
+	});
+
 };


### PR DESCRIPTION
Fixes #1.

cc @bakkot @michaelficarra